### PR TITLE
Add Klout access to main Tweet object and getter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,31 @@ I've also added simple command-line utility:
 ```
 python tools/tweet_parser.py -f"gnip_tweet_data.json" -c"created_at_string,all_text"
 ```
+
 ## Testing:
 A Python `test_tweet_parser.py` package exists in `test/`. 
 
 The most important thing that it tests is the equivalence of outputs when comparing both activity-streams input and original-format input. Any new getter will be tested by running `test$ python test_tweet_parser.py`, as the test checks every method attached to the Tweet object, for every test tweet stored in `test/tweet_payload_examples`. For any cases where it is expected that the outputs are different (e.g., outputs that depend on poll options), conditional statements should be added to this test.
 
 An option also exists for run-time checking of Tweet payload formats. This compares the set of all Tweet field keys to a superset of all possible keys, as well as a minimum set of all required keys, to make sure that each newly loaded Tweet fits those parameters. This shouldn't be run every time you load Tweets (for one, it's slow), but is implemented to use as a periodic check against Tweet format changes. This option is enabled with `--do_format_checking` on the command line, and by setting the keyword argument `do_format_checking` to `True` when initializing a `Tweet` object.
+
+## Contributing
+
+Submit bug reports or feature requests through GitHub Issues, with self-contained minimum working examples where appropriate.   
+
+To contribute code, the guidelines specified in the [`pandas` documentation](http://pandas.pydata.org/pandas-docs/stable/contributing.html#working-with-the-code) are a great reference. Fork this repo, create your own local feature branch, and create an isolated virtual environment (there are currently no external dependencies for this library). 
+
+Test your new feature by reinstalling the library in your virtual environment and running the test script as shown below. Fix any issues until all tests pass. 
+
+```bash
+(env) [tweet_parser]$ pip install -e . 
+(env) [tweet_parser]$ cd test/; python test_tweet_parser.py; cd - 
+``` 
+
+Furthermore, if contributing a new accessor or getter method for payload elements, verify the code works as you intended by running the `parse_tweets.py` script with your new field, as shown below. Check that both input types produce the intended output. 
+
+```bash
+(env) [tweet_parser]$ pip install -e . 
+(env) [tweet_parser]$ python tools/parse_tweets.py -f test/tweet_payload_examples/activity_streams_examples.json -c <your new field> 
+``` 
+ 

--- a/tweet_parser/getter_methods/tweet_user.py
+++ b/tweet_parser/getter_methods/tweet_user.py
@@ -29,3 +29,83 @@ def get_name(tweet):
         return tweet["user"]["name"]
     else:
         return tweet["actor"]["displayName"]
+
+
+def get_klout_score(tweet):
+    """ 
+    Return the user's Klout score (an int), if it exists.
+    """ 
+    try:
+        if is_original_format(tweet):
+            score = tweet['user']['derived']['klout']['score']
+        else:
+            score = tweet['gnip']['klout_score']
+        return score
+    except KeyError:
+        return None
+
+
+def get_klout_profile(tweet):
+    """ 
+    Return the user's Klout profile URL (an str), if it exists.
+    """ 
+    try:
+        if is_original_format(tweet):
+            profile = tweet['user']['derived']['klout']['profile_url']
+        else:
+            profile = tweet['gnip']['klout_profile']['link']
+        return profile
+    except KeyError:
+        return None
+
+
+def get_klout_id(tweet):
+    """ 
+    Return the user's Klout id (an str), if it exists.
+    """ 
+    try:
+        if is_original_format(tweet):
+            klout_id = tweet['user']['derived']['klout']['user_id']
+        else:
+            klout_id = tweet['gnip']['klout_profile']['klout_user_id']
+        return klout_id
+    except KeyError:
+        return None
+
+
+def get_klout_topics(tweet, topic_type='influence'):
+    """ 
+    Return the user's chosen Klout topics (a list of dicts), if it exists.
+
+    Regardless of the format or topic type, the topic dicts will have the same keys:
+        url, id, name, score 
+    """ 
+    try:
+        # check that the dict paths exist 
+        if is_original_format(tweet):
+            topics = tweet['user']['derived']['klout']['{}_topics'.format(topic_type)]
+        else:
+            topics = tweet['gnip']['klout_profile']['topics']
+    except KeyError:
+        return None
+    # since we have topics, collect the right pieces 
+    topics_list = []
+    if is_original_format(tweet):
+        for topic in topics:
+            # note: this is the same as the current structure of OF 
+            #  payloads, but is written out for consistency w/ AS payloads
+            this_topic = dict(url=topic['url'], 
+                                id=topic['id'],
+                                name=topic['name'],
+                                score=topic['score'])
+            topics_list.append(this_topic) 
+    else:
+        relevant_topics = [x for x in topics if x['topic_type'] == topic_type] 
+        for topic in relevant_topics:
+            this_topic = dict(url=topic['link'], 
+                                id=topic['id'],
+                                name=topic['displayName'],
+                                score=topic['score'])
+            topics_list.append(this_topic) 
+    return topics_list 
+

--- a/tweet_parser/tweet.py
+++ b/tweet_parser/tweet.py
@@ -73,6 +73,41 @@ class Tweet(dict):
         return tweet_user.get_name(self)
 
     @cached_property
+    def klout_score(self):
+        """
+        Return the user's Klout score (an int), if it exists. 
+        """
+        return tweet_user.get_klout_score(self)
+
+    @cached_property
+    def klout_profile(self):
+        """
+        Return the user's Klout profile URL (an str), if it exists. 
+        """
+        return tweet_user.get_klout_profile(self)
+
+    @cached_property
+    def klout_id(self):
+        """
+        Return the user's Klout id (a str), if it exists. 
+        """
+        return tweet_user.get_klout_id(self)
+
+    @cached_property
+    def klout_influence_topics(self):
+        """
+        Return the user's Klout influence topics (a list of dicts), if it exists. 
+        """
+        return tweet_user.get_klout_topics(self, topic_type='influence')
+
+    @cached_property
+    def klout_interest_topics(self):
+        """
+        Return the user's Klout interest topics (a list of dicts), if it exists. 
+        """
+        return tweet_user.get_klout_topics(self, topic_type='interest')
+
+    @cached_property
     def text(self):
         """
         literally the contents of 'text' or 'body'


### PR DESCRIPTION
I've added five new attributes to the main `Tweet` object, one for each of the primary Klout elements. There are four corresponding getter methods in the`tweet_user.py` module - since accessing the topic lists was very similar for influence and interest, I consolidated the two possible getters into one method with a keyword argument.